### PR TITLE
Spring의 컴포넌트 스캔과 자동 의존관계 주입 사용

### DIFF
--- a/src/main/java/com/example/demo/config/AutoConfig.java
+++ b/src/main/java/com/example/demo/config/AutoConfig.java
@@ -1,0 +1,15 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+import static org.springframework.context.annotation.ComponentScan.*;
+
+@Configuration
+@ComponentScan(
+        basePackages = "com.example.demo",
+        excludeFilters = @Filter(type = FilterType.ANNOTATION, classes = Configuration.class)
+)
+public class AutoConfig {
+}

--- a/src/main/java/com/example/demo/discount/RateDiscountPolicy.java
+++ b/src/main/java/com/example/demo/discount/RateDiscountPolicy.java
@@ -1,4 +1,19 @@
 package com.example.demo.discount;
 
-public class RateDiscountPolicy {
+import com.example.demo.member.Grade;
+import com.example.demo.member.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RateDiscountPolicy implements DiscountPolicy {
+
+    private int discountPercent = 10;
+
+    @Override
+    public int discount(Member member, int price) {
+        if (member.getGrade() == Grade.VIP) {
+            return price * discountPercent / 100;
+        }
+        return 0;
+    }
 }

--- a/src/main/java/com/example/demo/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/demo/member/MemberServiceImpl.java
@@ -1,8 +1,13 @@
 package com.example.demo.member;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
 
+    @Autowired
     public MemberServiceImpl(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }

--- a/src/main/java/com/example/demo/member/MemoryMemberRepository.java
+++ b/src/main/java/com/example/demo/member/MemoryMemberRepository.java
@@ -1,8 +1,11 @@
 package com.example.demo.member;
 
+import org.springframework.stereotype.Component;
+
 import java.util.HashMap;
 import java.util.Map;
 
+@Component
 public class MemoryMemberRepository implements MemberRepository {
 
     private static Map<Long, Member> store = new HashMap<>();

--- a/src/main/java/com/example/demo/order/OrderServiceImpl.java
+++ b/src/main/java/com/example/demo/order/OrderServiceImpl.java
@@ -3,12 +3,16 @@ package com.example.demo.order;
 import com.example.demo.discount.DiscountPolicy;
 import com.example.demo.member.Member;
 import com.example.demo.member.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class OrderServiceImpl implements OrderService {
 
     private final MemberRepository memberRepository;
     private final DiscountPolicy discountPolicy;
 
+    @Autowired
     public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;

--- a/src/test/java/com/example/demo/config/AutoConfigTest.java
+++ b/src/test/java/com/example/demo/config/AutoConfigTest.java
@@ -1,0 +1,17 @@
+package com.example.demo.config;
+
+import com.example.demo.member.MemberService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+class AutoConfigTest {
+    @Test
+    @DisplayName("컴포넌트 스캔으로 스프링 컨테이너에 빈 등록 테스트")
+    void componentScan() {
+        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AutoConfig.class);
+        MemberService memberService = ac.getBean("memberServiceImpl", MemberService.class); // 컴포넌트 스캔에서 등록한 빈이름은 클래스의 일므에서 앞글자만 소문자로 하여 저장함.
+        Assertions.assertThat(memberService).isInstanceOf(MemberService.class);
+    }
+}


### PR DESCRIPTION
```@Component``` : 컴포넌트 스캔의 대상으로, 스프링 컨테이너에 빈을 등록하는 기능이다.
```@ComponentScan``` : 컴포넌트를 스캔하는 기능으로, 클래스에 ```@Component```가 붙은 클래스들을 인스턴스를 생성하여 빈으로 등록한다. 이때 빈 이름은 클래스의 앞글자만 소문자로 하여 빈을 등록한다. ex) class MemberServicImpl -> memberServiceImpl로 등록
```@Autowired``` : 컴포넌트 스캔으로 빈을 생성하면 의존관계 주입에 해당하는 것은 ```@Autowired```를 통해 주입된다.